### PR TITLE
Fix starting date bug

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -19,7 +19,7 @@ exports.index = function (req, res) {
         deferred = q.defer();
 
         options = {
-            q: '-label:invalid+created:2017-09-30T00:00:00-12:00..2017-10-31T23:59:59-12:00+type:pr+is:public+author:' + username
+            q: '-label:invalid+created:2017-10-01T00:00:00-12:00..2017-10-31T23:59:59-12:00+type:pr+is:public+author:' + username
         };
 
         github.search.issues(options, function (err, res) {


### PR DESCRIPTION
Hi,

According to this tweet from Digital Ocean, PRs made the 30th of September won't count. I've fixed that in the 2017 correction version of the app 👍 

<blockquote class="twitter-tweet" data-lang="es"><p lang="en" dir="ltr">No, it wouldn&#39;t count. They will only count from October 1 - 31</p>&mdash; DigitalOcean (@digitalocean) <a href="https://twitter.com/digitalocean/status/914144872420003840?ref_src=twsrc%5Etfw">30 de septiembre de 2017</a></blockquote>

Best regards,
Marta

PD: This should be fixed also in @jenkoian's version (https://github.com/jenkoian/hacktoberfest-checker )